### PR TITLE
feat: API mechanism

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -81,6 +81,44 @@ mechanisms:
         fov: 40
         sampling_mode: bicubic
         padding_mode: border
+  - # Name of this parameter set within the config. Can be referenced in scenes
+    name: api
+    # Name of the mechanism to use
+    type: api
+    # Arbitrary parameters the text2video mechanism can take. These are always implementation specific
+    mechanism_parameters:
+      host: http://localhost:7860
+      seed: 123456
+      # Additional parameters to format the txt2img request body template with (prompt is auto-filled)
+      txt2img_params:
+        steps: 20
+        # Euler a, LMS, ...
+        sampler: LMS
+        scale: 7.0
+        W: 768
+        H: 512
+      img2img_params:
+        steps: 20
+        # Euler a, LMS, ...
+        sampler: LMS
+        scale: 7.0
+        W: 768
+        H: 512
+        # This is denoising strength here, lower = better flow
+        strength: 0.45
+      # Type of animation to apply between frames, if any
+      animation: 3D
+      # Parameters for the animation
+      animation_parameters:
+        translation_x: 0
+        translation_y: beat*2*1*sin(1/4*t)
+        translation_z: 0.5+beat*7
+        # depth model parameters
+        near_plane: 200
+        far_plane: 10000
+        fov: 40
+        sampling_mode: bicubic
+        padding_mode: border
 # Other, global multi-modal context
 additional_context:
   audio_reactivity:

--- a/t2v/animation/animator_3d.py
+++ b/t2v/animation/animator_3d.py
@@ -1,17 +1,13 @@
 import logging
-import math
-import os
 import sys
 
-import torch
-import cv2
 import numpy as np
+import torch
 from einops import rearrange
 from omegaconf import DictConfig
 
-from t2v.animation.func_tools import FuncUtil
-from t2v.animation.helpers import AnimationUtils
 from t2v.animation.animator import Animator
+from t2v.animation.helpers import AnimationUtils
 from t2v.config.root import RootConfig
 from t2v.mechanism.helpers_stablediff.depth import DepthModel
 

--- a/t2v/mechanism/api_mechanism.py
+++ b/t2v/mechanism/api_mechanism.py
@@ -1,0 +1,228 @@
+import base64
+import io
+import logging
+
+import numpy as np
+from PIL import Image
+from omegaconf import DictConfig
+
+from t2v.animation.func_tools import FuncUtil
+from t2v.config.root import RootConfig
+
+from t2v.mechanism.mechanism import Mechanism
+
+import requests
+
+# Generated with revision e22ea454a273b3a8a807a5acb2e6f0d0d41c9aa7,
+# diff the template with a captured query of a more recent version to update these when necessary
+from t2v.mechanism.turbo_stablediff_functions import add_noise, sample_from_cv2, sample_to_cv2
+
+TXT2IMG = """
+{{
+"fn_index": 12,
+  "data": [
+    "{prompt}",
+    "",
+    "None",
+    "None",
+    {steps},
+    "{sampler}",
+    false,
+    false,
+    1,
+    1,
+    {scale},
+    {seed},
+    -1,
+    0,
+    0,
+    0,
+    false,
+    {H},
+    {W},
+    false,
+    false,
+    0.7,
+    "None",
+    false,
+    null,
+    "",
+    false,
+    "Seed",
+    "",
+    "Steps",
+    "",
+    true,
+    null,
+    "",
+    ""
+  ],
+  "session_hash": "djrqd1giwif"
+}}
+"""
+
+IMG2IMG = """
+{{
+"fn_index": 30,
+    "data": [
+        0,
+        "{prompt}",
+        "",
+        "None",
+        "None",
+        "data:image/png;base64,{pngbase64}",
+        null,
+        null,
+        null,
+        "Draw mask",
+        {steps},
+        "{sampler}",
+        4,
+        "fill",
+        false,
+        false,
+        1,
+        1,
+        {scale},
+        {strength},
+        {seed},
+        -1,
+        0,
+        0,
+        0,
+        false,
+        {H},
+        {W},
+        "Just resize",
+        false,
+        32,
+        "Inpaint masked",
+        "",
+        "",
+        "None",
+        "",
+        "",
+        1,
+        50,
+        0,
+        false,
+        4,
+        1,
+        "",
+        128,
+        8,
+        [
+            "left",
+            "right",
+            "up",
+            "down"
+        ],
+        1,
+        0.05,
+        128,
+        4,
+        "fill",
+        [
+            "left",
+            "right",
+            "up",
+            "down"
+        ],
+        false,
+        null,
+        "",
+        false,
+        "",
+        64,
+        "None",
+        "Seed",
+        "",
+        "Steps",
+        "",
+        true,
+        false,
+        null,
+        ""
+],
+"session_hash": "djrqd1giwif"
+}}"""
+
+
+class ApiMechanism(Mechanism):
+    def __init__(self, config: DictConfig, root_config: RootConfig, func_util: FuncUtil):
+        super().__init__(config, root_config, func_util)
+        self.root_config = root_config
+        self.config = config
+        self.func_util = func_util
+        self.host = self.config.get("host")
+        self.index = 0
+
+    def generate(self, config: DictConfig, context, prompt: str, t):
+        # TODO: template out the queries, run txt2img, decode the image
+        # TODO: on subsequent steps, run img2img, encode the previous frame as base64 and use as input
+        # TODO: warping code from other mechanism
+
+        # TODO move into base class method
+        # TODO not sure if this works as intended for nested dicts
+        # config overlaying
+        if config is not None:
+            config_param = self.config.copy()
+            config_param.update(config)
+        else:
+            config_param = self.config
+        if "prev_frame" not in context:
+            img = self._txt2img(prompt, config_param)
+        else:
+            prev_frame = context["prev_frame"]
+            warped_frame = self.animator.apply(np.array(prev_frame).astype(np.uint8), prompt,
+                                               self.config.get("animation_parameters"), t)
+            noised_sample = add_noise(sample_from_cv2(warped_frame), 0.02)
+            noised_sample = sample_to_cv2(noised_sample)
+            img = self._img2img(prompt, config_param, Image.fromarray(noised_sample))
+        self.index = self.index + 1
+        return img, {
+            "prev_frame": img
+        }
+
+    def _txt2img(self, prompt: str, config_param: DictConfig):
+        body = TXT2IMG.format(prompt=prompt, **config_param.get("txt2img_params"),
+                              seed=config_param.get("seed") + self.index)
+        res = requests.post(f"{self.host}/api/predict/",
+                            data=body)
+        if res.status_code == 200:
+            json = res.json()
+            # We just assume the expected format for now. Errors in the format received from the API lead to crashes.
+            # Remove prefix: data:image/png;base64,
+            image = base64.b64decode(json['data'][0][0][22:])
+            return Image.open(io.BytesIO(image))
+        else:
+            logging.error(f"API request failed, response code {res.status_code}, response body: {res.raw}")
+            logging.error(f"Original request body: {body}")
+            raise RuntimeError("Unexpected non-200 exit code")
+
+    def _img2img(self, prompt: str, config_param: DictConfig, img: Image):
+        # Encode image
+        buffered = io.BytesIO()
+        img.save(buffered, format="PNG")
+
+        # clip off the "byte" indicators in the result string
+        img_str = str(base64.b64encode(buffered.getvalue()))[2:-1]
+        body = IMG2IMG.format(prompt=prompt, **config_param.get("img2img_params"), pngbase64=img_str,
+                              seed=config_param.get("seed") + self.index)
+        res = requests.post(f"{self.host}/api/predict/",
+                            data=body)
+        if res.status_code == 200:
+            json = res.json()
+            # We just assume the expected format for now. Errors in the format received from the API lead to crashes.
+            return Image.open(io.BytesIO(base64.b64decode(json['data'][0][0][22:])))
+        else:
+            logging.error(f"API request failed, response code {res.status_code}, response body: {res.json()}")
+            logging.error(f"Original request body: {body}")
+            raise RuntimeError("Unexpected non-200 exit code")
+
+    def destroy(self):
+        super().destroy()
+
+    @staticmethod
+    def name():
+        return "api"

--- a/t2v/mechanism/turbo_stablediff_functions.py
+++ b/t2v/mechanism/turbo_stablediff_functions.py
@@ -140,7 +140,7 @@ def sample_to_cv2(sample: torch.Tensor, type=np.uint8) -> np.ndarray:
 
 
 def add_noise(sample: torch.Tensor, noise_amt: float) -> torch.Tensor:
-    return sample - noise_amt + torch.randn(sample.shape, device=sample.device) * noise_amt
+    return sample - (noise_amt/2) + torch.randn(sample.shape, device=sample.device) * noise_amt
 
 
 def get_output_folder(output_path, batch_folder):

--- a/t2v/mechanism/turbo_stablediff_functions.py
+++ b/t2v/mechanism/turbo_stablediff_functions.py
@@ -240,20 +240,6 @@ class TurboStableDiffUtils:
         mask = np.clip(mask, 0, 1)
         return mask
 
-    def maintain_colors(self, prev_img, color_match_sample, mode):
-        if mode == 'Match Frame 0 RGB':
-            return match_histograms(prev_img, color_match_sample, multichannel=True)
-        elif mode == 'Match Frame 0 HSV':
-            prev_img_hsv = cv2.cvtColor(prev_img, cv2.COLOR_RGB2HSV)
-            color_match_hsv = cv2.cvtColor(color_match_sample, cv2.COLOR_RGB2HSV)
-            matched_hsv = match_histograms(prev_img_hsv, color_match_hsv, multichannel=True)
-            return cv2.cvtColor(matched_hsv, cv2.COLOR_HSV2RGB)
-        else:  # Match Frame 0 LAB
-            prev_img_lab = cv2.cvtColor(prev_img, cv2.COLOR_RGB2LAB)
-            color_match_lab = cv2.cvtColor(color_match_sample, cv2.COLOR_RGB2LAB)
-            matched_lab = match_histograms(prev_img_lab, color_match_lab, multichannel=True)
-            return cv2.cvtColor(matched_lab, cv2.COLOR_LAB2RGB)
-
     def make_callback(self, sampler_name, dynamic_threshold=None, static_threshold=None, mask=None, init_latent=None,
                       sigmas=None,
                       sampler=None, masked_noise_modifier=1.0):
@@ -803,3 +789,18 @@ class DeforumAnimKeys():
                                                        anim_args.max_frames)
         self.contrast_schedule_series = get_inbetweens(parse_key_frames(anim_args.contrast_schedule),
                                                        anim_args.max_frames)
+
+
+def maintain_colors(prev_img, color_match_sample, mode):
+    if mode == 'Match Frame 0 RGB':
+        return match_histograms(prev_img, color_match_sample, multichannel=True)
+    elif mode == 'Match Frame 0 HSV':
+        prev_img_hsv = cv2.cvtColor(prev_img, cv2.COLOR_RGB2HSV)
+        color_match_hsv = cv2.cvtColor(color_match_sample, cv2.COLOR_RGB2HSV)
+        matched_hsv = match_histograms(prev_img_hsv, color_match_hsv, multichannel=True)
+        return cv2.cvtColor(matched_hsv, cv2.COLOR_HSV2RGB)
+    else:  # Match Frame 0 LAB
+        prev_img_lab = cv2.cvtColor(prev_img, cv2.COLOR_RGB2LAB)
+        color_match_lab = cv2.cvtColor(color_match_sample, cv2.COLOR_RGB2LAB)
+        matched_lab = match_histograms(prev_img_lab, color_match_lab, multichannel=True)
+        return cv2.cvtColor(matched_lab, cv2.COLOR_LAB2RGB)

--- a/t2v/mechanism/turbo_stablediff_mechanism.py
+++ b/t2v/mechanism/turbo_stablediff_mechanism.py
@@ -7,7 +7,7 @@ from pytorch_lightning import seed_everything
 
 from t2v.mechanism.mechanism import Mechanism
 from t2v.mechanism.turbo_stablediff_functions import DeforumArgs, TurboStableDiffUtils, sample_to_cv2, sample_from_cv2, \
-    add_noise
+    add_noise, maintain_colors
 
 
 class TurboStableDiff(Mechanism):
@@ -64,7 +64,7 @@ class TurboStableDiff(Mechanism):
             #            cv2.cvtColor(warped_frame.astype(np.uint8), cv2.COLOR_RGB2BGR))
             # apply color matching
             if self.color_match_sample is not None:
-                warped_frame = self.utils.maintain_colors(warped_frame, self.color_match_sample, 'Match Frame 0 LAB')
+                warped_frame = maintain_colors(warped_frame, self.color_match_sample, 'Match Frame 0 LAB')
 
             # TODO: parameters for contrast schedule, noise schedule
             # apply scaling
@@ -93,7 +93,7 @@ class TurboStableDiff(Mechanism):
             args["steps"] = args["turbo_sampling_steps"]
             samples, image = self.utils.generate(args, return_sample=True)
 
-        if self.index == 0:
+        if self.color_match_sample is None:
             self.color_match_sample = sample_to_cv2(samples)
 
         self.index = self.index + 1

--- a/t2v/runner.py
+++ b/t2v/runner.py
@@ -10,6 +10,7 @@ from t2v.animation.audio_parse_beats import BeatAudioParser
 from t2v.animation.func_tools import FuncUtil
 from t2v.config.root import RootConfig
 from t2v.config.scene import Scene
+from t2v.mechanism.api_mechanism import ApiMechanism
 from t2v.mechanism.noop_mechanism import NoopMechanism
 from t2v.mechanism.turbo_stablediff_mechanism import TurboStableDiff
 
@@ -28,6 +29,7 @@ class Runner:
         self.mechanism_types = {
             TurboStableDiff.name(): TurboStableDiff,
             NoopMechanism.name(): NoopMechanism,
+            ApiMechanism.name(): ApiMechanism
         }
         self.cfg = cfg
         # Stores instantiated mechanism objects by their name within the config


### PR DESCRIPTION
basic version of a mechanism implementation that instead of loading the stable diff model and running inference on it directly, just queries, in this case automatic1111's fork of the sd-web-ui on its txt2img and img2img endpoints. It works, but flow stability is not great and hard to manage.

Additionally, until it gets a proper REST-API, the request body templates will break occasionally when UI changes happen upstream.